### PR TITLE
Add Firefox data collection permissions metadata

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,10 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "minimal-volume-booster@example.com",
-      "strict_min_version": "109.0"
+      "strict_min_version": "109.0",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- declare that the extension collects no data using the required `none` value in the Firefox-specific manifest section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e414461704832fa6dc528864c01035