### PR TITLE
Fix volume attenuation below 100% in Firefox

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Minimal Volume Booster",
   "description": "Boost tab audio volume up to 600%",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "manifest_version": 3,
   "action": {
     "default_title": "Volume Booster",

--- a/popup.js
+++ b/popup.js
@@ -162,20 +162,38 @@ async function runSetVolume(tabId, multiplier) {
   throw new Error('No compatible scripting API available.');
 }
 function setVolume(multiplier) {
-  if (!Number.isFinite(multiplier)) return;
+  if (!Number.isFinite(multiplier) || multiplier < 0) return;
   window.__mvbMultiplier = multiplier;
 
   const apply = () => {
     document.querySelectorAll('video,audio').forEach(el => {
-      if (!el.__mvbCtx) {
-        const ctx = new (window.AudioContext || window.webkitAudioContext)();
-        const source = ctx.createMediaElementSource(el);
-        const gain = ctx.createGain();
-        source.connect(gain);
-        gain.connect(ctx.destination);
-        el.__mvbCtx = { ctx, gain };
+      const m = window.__mvbMultiplier;
+
+      // Native volume handles attenuation (0-100%) reliably in every browser.
+      // Firefox does not attenuate media routed through Web Audio (bug 966247),
+      // so relying on the gain node alone leaves the element at full volume.
+      el.volume = Math.min(1, m);
+
+      // Only boosting above 100% needs the Web Audio gain node. Effective
+      // output is el.volume * gain, so this stays correct in Chrome too.
+      if (m > 1 && !el.__mvbCtx) {
+        try {
+          const ctx = new (window.AudioContext || window.webkitAudioContext)();
+          const source = ctx.createMediaElementSource(el);
+          const gain = ctx.createGain();
+          source.connect(gain);
+          gain.connect(ctx.destination);
+          el.__mvbCtx = { ctx, gain };
+        } catch (e) {
+          // createMediaElementSource can throw (e.g. cross-origin media);
+          // native el.volume still applies as a fallback.
+        }
       }
-      el.__mvbCtx.gain.gain.value = window.__mvbMultiplier;
+
+      if (el.__mvbCtx) {
+        if (el.__mvbCtx.ctx.state === 'suspended') el.__mvbCtx.ctx.resume();
+        el.__mvbCtx.gain.gain.value = Math.max(1, m);
+      }
     });
   };
 


### PR DESCRIPTION
## Summary
- Firefox does not attenuate media routed through Web Audio ([bug 966247](https://bugzilla.mozilla.org/show_bug.cgi?id=966247)), so setting the gain node below 1.0 had no effect — dragging the slider under 100% did nothing.
- Attenuation (0–100%) now uses the media element's native `volume`, which every browser honors reliably. The Web Audio gain node is used only for boosting above 100%.
- Effective output is `el.volume * gain` (`min(1, m)` × `max(1, m)`), so Chrome behavior is unchanged.
- `createMediaElementSource` is wrapped in try/catch (throws on cross-origin media) and a suspended `AudioContext` is resumed.
- Version bumped to 1.0.2.

## Testing
- `node --check popup.js` passes.
- Not yet runtime-verified in a live Firefox instance — recommend loading via `about:debugging` and confirming the slider attenuates below 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)